### PR TITLE
send message instead of using attributes hash

### DIFF
--- a/lib/anjlab-widgets/simple_form.rb
+++ b/lib/anjlab-widgets/simple_form.rb
@@ -7,7 +7,7 @@ module Anjlab
       end
 
       def input
-        time = options[:value] || @builder.object[attribute_name]
+        time = options[:value] || @builder.object.send(attribute_name)
 
         html = ''.html_safe
 


### PR DESCRIPTION
I have a form where a `scheduled_for_local` is used in the form but it isn't an attribute in the database on the model. I translate from the local time to UTC before persisting.

Anyways, using the `[]` method caused an error. I switched to send the attribute message to the object instead.
