### PR TITLE
add placeholder functionality to date and time inputs in simpleform

### DIFF
--- a/lib/anjlab-widgets/simple_form.rb
+++ b/lib/anjlab-widgets/simple_form.rb
@@ -19,7 +19,8 @@ module Anjlab
           "data-date-allow-blank" => allow_blank,
           :value => Widgets::format_date(time),
           :required => input_html_options[:required],
-          :class => "#{input_html_options[:date_class] || 'input-small'}"
+          :class => "#{input_html_options[:date_class] || 'input-small'}",
+          :placeholder => "#{input_html_options[:date_placeholder]}"
         }.merge(input_html_options)
 
         time_data = {
@@ -27,7 +28,8 @@ module Anjlab
           "data-rails" => true,
           :value => Widgets::format_time(time),
           :required => input_html_options[:required],
-          :class => "#{input_html_options[:time_class] || 'input-small'}"
+          :class => "#{input_html_options[:time_class] || 'input-small'}",
+          :placeholder => "#{input_html_options[:time_placeholder]}"
         }.merge(input_html_options)
 
         case input_type


### PR DESCRIPTION
Allows placeholders to be set for date and time in the same way that classes are:

`f.input :when, input_html: { date_placeholder: "Date", time_placeholder: "Time" }`
